### PR TITLE
Explicitly link with the XScreenSaver library.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,3 @@
 all:
 	$(CC) -fPIC  -O2 -g -Wall -o sluggish.so -shared sluggish.c \
-	    `pkg-config --cflags --libs purple-3` -DUSE_SCREENSAVER
+	    `pkg-config --cflags --libs purple-3` -DUSE_SCREENSAVER -lXss

--- a/src/sluggish.c
+++ b/src/sluggish.c
@@ -21,8 +21,6 @@
  *
  */
 
-#define DEBUG_BUILD
-
 #ifdef HAVE_CONFIG_H
 # include <config.h>
 #endif


### PR DESCRIPTION
Recent changes to libpurple3-git seem to no longer link with Xss so link with it ourselves.